### PR TITLE
Adding Scroll to Modal

### DIFF
--- a/styles/modal.css
+++ b/styles/modal.css
@@ -6,6 +6,7 @@
   right: 0;
   bottom: 0;
   left: 0;
+  overflow-y: auto;
 }
 
 .modal--content {


### PR DESCRIPTION
# Adding Scroll to Modal

Fixes issue where some modals were too long on the y-axis to be fully viewed. If the modal does not fit by itself, a scroll bar will appear on the modal

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

```
git fetch --all
git checkout <branch-name>
```

# Checklist:
- [ ] Log in as Jade, who has several orders
- [ ] Resize the window so the modal is too large to fit
- [ ] Ensure that the user can reach the "close" button by scrolling
